### PR TITLE
Allowing the Road action to be either index or the actual road object

### DIFF
--- a/game/controllers/action_controller.py
+++ b/game/controllers/action_controller.py
@@ -74,7 +74,7 @@ class ActionController(Controller):
     def move(self, player):
         param = player.action.action_parameter
         if type(param) == int:
-            road = player.truck.map.current_node.roads[param]
+            road = player.truck.active_contract.game_map.current_node.roads[param]
         elif type(param) == Road:
             road = param
         else:


### PR DESCRIPTION
It used to accept only the road object. This should also accept the index of the road_map list.