### PR TITLE
Fixed random generation

### DIFF
--- a/game/controllers/master_controller.py
+++ b/game/controllers/master_controller.py
@@ -49,6 +49,7 @@ class MasterController(Controller):
     # Receives world data from the generated game log and is responsible for interpreting it
     def interpret_current_turn_data(self, client, world, turn):
         self.current_world_data = world
+        random.seed(world["seed"])
 
     # Receive a specific client and send them what they get per turn. Also obfuscates necessary objects.
     def client_turn_arguments(self, client, turn):
@@ -60,8 +61,6 @@ class MasterController(Controller):
 
         client.truck.contract_list = copy.deepcopy(contract_list)
         client.action = actions
-
-
 
         # Create deep copies of all objects sent to the player
 
@@ -81,8 +80,6 @@ class MasterController(Controller):
     event = EventType.none
     # Perform the main logic that happens per turn
     def turn_logic(self, client, turn):
-        random.seed(self.current_world_data["seed"])
-
         new_action = self.action_controller.handle_actions(client)
         if not isinstance(new_action, int):
             self.selected_action = new_action[0]


### PR DESCRIPTION
Due to randomness happening in the "client_turn_arguments" function, which was happening before the "turn_logic" function (where the random seed was being set), there were discrepancies between runs of the game. To fix this, I moved the random seed setting to interpret world data, which should be before any turn logic stuff. It seems to fix all the randomness. 